### PR TITLE
FIX: Minor style issues discovered on meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Ghost
+
+A cyberpunk theme for Discourse
+
+[Learn more](https://meta.discourse.org/t/ghost-a-cyberpunk-theme-for-discourse/111806?u=melhosseiny)

--- a/about.json
+++ b/about.json
@@ -2,9 +2,9 @@
   "name": "Ghost",
   "component": false,
   "license_url": "https://github.com/melhosseiny/ghost/blob/master/ghost/LICENSE",
-  "about_url": null,
+  "about_url": "https://meta.discourse.org/t/ghost-a-cyberpunk-theme-for-discourse/111806?u=melhosseiny",
   "authors": "https://github.com/melhosseiny",
-  "theme_version": null,
+  "theme_version": "0.0.1",
   "minimum_discourse_version": null,
   "maximum_discourse_version": null,
   "assets": {

--- a/common/common.scss
+++ b/common/common.scss
@@ -708,6 +708,10 @@ aside.quote .title {
 	100% { background-color: rgba(33,36,36,1); }
 }
 
+.show-more.has-topics {
+  position: static;
+}
+
 .topic-list {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1019,6 +1023,19 @@ aside.onebox {
       width: 4px;
       height: 8px;
     }
+  }
+}
+
+.badge-notification {
+  padding: 0;
+  &.new-posts, &.unread {
+    background-color: transparent;
+  }
+  &.new-posts {
+    color: $tertiary;
+  }
+  &.unread {
+    color: $highlight;
   }
 }
 

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -106,6 +106,13 @@ $bios: #1d3bf0;
   margin-right: 8px;
 }
 
+.topic-avatar {
+  .avatar-flair {
+    top: 35px;
+    right: 0;
+  }
+}
+
 // base:topic
 .post-menu-area {
   margin-right: 8px;


### PR DESCRIPTION
- Declare `position:static` for `.show-more.has-topics` to avoid overlap with topic list
- Remove `padding`, `background` from topic unread and new post notifications and set color to `$highlight` and `$tertiary`
- Reposition topic avatar flair on desktop at `top:35px`, `right:0`
- Set `about_url`, `theme_version` in `about.json`
- Add short theme description and learn more link to README