### PR TITLE
FEATURE: Add invert-logo theme setting

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -202,9 +202,11 @@ blockquote {
 .d-header {
   background: $background;
   box-shadow: none;
-  .logo-big, #site-logo {
-    -webkit-filter: invert(1);
-            filter: invert(1);
+  @if $invert-logo == "true" {
+    .logo-big, #site-logo {
+      -webkit-filter: invert(1);
+              filter: invert(1);
+    }
   }
   .d-header-icons {
     .icon {

--- a/settings.yml
+++ b/settings.yml
@@ -1,0 +1,3 @@
+invert-logo:
+  type: bool
+  default: true


### PR DESCRIPTION
Add invert-logo bool theme setting to disable a `filter: invert(1)` rule applied to `.d-header .logo-big, .d-header #site-logo`