### PR TITLE
Fix transparent avatars

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -157,7 +157,6 @@ div.ac-wrap,
 // img avatars
 img.avatar {
   display: inline-block;
-  background-color: #00d0c1;
   border-bottom: 2px solid $highlight;
   border-radius: 0;
 }


### PR DESCRIPTION
Found a bug on my forum where users with transparent avatars would have a blue background instead of transparency. 
![non-transparent-avatar](https://user-images.githubusercontent.com/10913120/103079679-e6d58d80-4599-11eb-94c7-d4565951ead0.PNG)

Removing `background-color: #00d0c1;` allows for transparency to be shown through
![transparent-avatar](https://user-images.githubusercontent.com/10913120/103079737-11274b00-459a-11eb-810c-03463daa5830.PNG)
