### PR TITLE
FIX: Missing bios variable in desktop.scss

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -1,5 +1,7 @@
 // color
 
+@import "variables";
+
 // base:group(s)
 .group {
   .user-table {


### PR DESCRIPTION
fixed the missing bios colour variable in the desktop.scss file by importing the variables scss file which includes it.

Signed-off-by: Michael <michael.lindman@gmail.com>