### PR TITLE
UX: Add sidebar support

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,6 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Condensed&family=Overpass+Mono&display=swap');
 
 @import "variables";
+@import "sidebar";
 
 // admin:admin_base
 .admin-contents {

--- a/scss/sidebar.scss
+++ b/scss/sidebar.scss
@@ -35,7 +35,7 @@
   }
   &:hover {
     color: rgb(255, 255, 255);
-    background-color: var(--tertiary) !important;
+    background-color: var(--tertiary);
     border-radius: 4px;
     box-shadow: 0 0 25px -3px var(--tertiary);
 

--- a/scss/sidebar.scss
+++ b/scss/sidebar.scss
@@ -1,0 +1,57 @@
+.sidebar-wrapper {
+  background-color: var(--secondary);
+  margin-top: 2.5em;
+
+  .sidebar-section-link-wrapper {
+    .sidebar-section-link {
+      &:hover {
+        background-color: rgba(33, 36, 36, 1);
+        animation-name: fade-in-rgba;
+        animation-iteration-count: 1;
+        animation-timing-function: ease-in;
+        animation-duration: 100ms;
+      }
+    }
+  }
+
+  .sidebar-footer-wrapper {
+    background: var(--secondary);
+    .sidebar-footer-container {
+      background: none;
+      &:before {
+        background: linear-gradient(
+          to bottom,
+          transparent,
+          rgba(var(--secondary-rgb), 1)
+        );
+      }
+    }
+  }
+}
+
+.discourse-no-touch .sidebar-section-wrapper .sidebar-section-header-wrapper {
+  .btn:hover {
+    background: none;
+  }
+  &:hover {
+    color: rgb(255, 255, 255);
+    background-color: var(--tertiary) !important;
+    border-radius: 4px;
+    box-shadow: 0 0 25px -3px var(--tertiary);
+
+    .sidebar-section-header-button .d-icon {
+      color: var(--primary);
+    }
+  }
+}
+
+.discourse-no-touch
+  .sidebar-section-wrapper
+  .sidebar-section-header-wrapper
+  .btn.dropdown-select-box-header:hover,
+.discourse-no-touch
+  .sidebar-section-wrapper
+  .sidebar-section-header-wrapper
+  .sidebar-section-header-button:hover {
+  background: none;
+}


### PR DESCRIPTION
This PR adds sidebar support to the theme:

Only some simple style changes to match theme color scheme and alignment was necessary.

Before:
<img width="1512" alt="Screen Shot 2022-08-30 at 4 07 05 PM" src="https://user-images.githubusercontent.com/30090424/187559027-38985c65-3a47-4f88-8e1d-1f217bc2a217.png">

After:
<img width="1512" alt="Screen Shot 2022-08-30 at 4 07 16 PM" src="https://user-images.githubusercontent.com/30090424/187559044-71f1c041-a13d-4900-b4f5-1eab64dd0eee.png">

